### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,52 +6,52 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Finger			KEYWORD1
-FingerLib		KEYWORD1
+Finger	KEYWORD1
+FingerLib	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-attach				KEYWORD2
-detach				KEYWORD2
-attached			KEYWORD2
-invertFingerDir		KEYWORD2
+attach	KEYWORD2
+detach	KEYWORD2
+attached	KEYWORD2
+invertFingerDir	KEYWORD2
 
-setPosLimits		KEYWORD2
-setPWMLimits		KEYWORD2
-setForceLimits		KEYWORD2
+setPosLimits	KEYWORD2
+setPWMLimits	KEYWORD2
+setForceLimits	KEYWORD2
 
-writePos			KEYWORD2
-movePos				KEYWORD2
-readPos				KEYWORD2
-readPosError		KEYWORD2
-readTargetPos		KEYWORD2
-reachedPos			KEYWORD2
+writePos	KEYWORD2
+movePos	KEYWORD2
+readPos	KEYWORD2
+readPosError	KEYWORD2
+readTargetPos	KEYWORD2
+reachedPos	KEYWORD2
 
-writeDir			KEYWORD2
-readDir				KEYWORD2
-open				KEYWORD2
-close				KEYWORD2
-open_close			KEYWORD2
+writeDir	KEYWORD2
+readDir	KEYWORD2
+open	KEYWORD2
+close	KEYWORD2
+open_close	KEYWORD2
 
-writeSpeed			KEYWORD2
-readSpeed			KEYWORD2
-readTargetSpeed		KEYWORD2
-readPWM				KEYWORD2
-readTargetPWM		KEYWORD2
+writeSpeed	KEYWORD2
+readSpeed	KEYWORD2
+readTargetSpeed	KEYWORD2
+readPWM	KEYWORD2
+readTargetPWM	KEYWORD2
 
 
-readForce			KEYWORD2
-readCurrent			KEYWORD2
+readForce	KEYWORD2
+readCurrent	KEYWORD2
 reachedForceLimit	KEYWORD2
 convertADCToForce	KEYWORD2
 convertForceToADC	KEYWORD2
 
-stopMotor			KEYWORD2
-motorEnable			KEYWORD2
-enabled				KEYWORD2
+stopMotor	KEYWORD2
+motorEnable	KEYWORD2
+enabled	KEYWORD2
 forceSenseEnable	KEYWORD2
-enableInterrupt		KEYWORD2
+enableInterrupt	KEYWORD2
 disableInterrupt	KEYWORD2
 
 # printPos	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords